### PR TITLE
Update for kubernetes 1.22

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -11,6 +11,7 @@ description: |
 name: rancher-externalip-webhook
 version: %VERSION%
 appVersion: %APP_VERSION%
+kubeVersion: '>=1.16.0-0'
 home: https://github.com/rancher/externalip-webhook
 sources:
   - https://github.com/rancher/externalip-webhook

--- a/chart/templates/admissionregistration.yaml
+++ b/chart/templates/admissionregistration.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
 {{- if .Values.certificates.certManager.enabled }}
@@ -28,3 +28,5 @@ webhooks:
     - UPDATE
     resources:
     - services
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None

--- a/chart/tests/admissionregistration_test.yaml
+++ b/chart/tests/admissionregistration_test.yaml
@@ -6,7 +6,7 @@ tests:
   asserts:
   - equal:
       path: apiVersion
-      value: admissionregistration.k8s.io/v1beta1
+      value: admissionregistration.k8s.io/v1
 - it: should render Admission Registration annotation and not caBundle if certificates.certManager.enabled = true
   release:
     name: rancher-externalip-webhook

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,7 +1,7 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/config/metrics_server_rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/metrics_server_rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
@@ -24,3 +24,5 @@ webhooks:
     - UPDATE
     resources:
     - services
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None


### PR DESCRIPTION
Update ValidatingWebhookConfiguration and ClusterRole resources to use
apiVersion v1 for compatibility with kubernetes 1.22.

https://github.com/rancher/rancher/issues/33513