### PR TITLE
Cap supported kubernetes version to <1.22 in chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 created to address [CVE-2020-8554](https://www.cvedetails.com/cve/CVE-2020-8554/)
 
+**Note:** This chart is deprecated for kubernetes version 1.21 and unsupported starting with 1.22. To mitigate CVE-2020-8554, enable the [`DenyServiceExternalIPs` admission controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#denyserviceexternalips) on the cluster.
+
 externalip-webhook, is a validating webhook which prevents services from using random external IPs. Cluster administrators
 can specify list of CIDRs allowed to be used as external IP by specifying `allowed-external-ip-cidrs` parameter.
 Webhook will only allow creation of services which doesn't require external IP or whose external IPs are within the range

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -11,6 +11,7 @@ description: |
 name: rancher-externalip-webhook
 version: %VERSION%
 appVersion: %APP_VERSION%
+kubeVersion: < 1.22.0
 home: https://github.com/rancher/externalip-webhook
 sources:
   - https://github.com/rancher/externalip-webhook

--- a/chart/README.md
+++ b/chart/README.md
@@ -2,7 +2,9 @@
 
 ## Chart Details
 
-This chart will create a deployment of `externalip-webhook` within your Kubernetes Cluster. It's required to mitigate k8s CVE-2020-8554.
+This chart will create a deployment of `externalip-webhook` within your Kubernetes Cluster. It is required on kubernetes versions prior to 1.21 to mitigate CVE-2020-8554.
+
+**Note:** This chart is deprecated for kubernetes version 1.21 and unsupported starting with 1.22. To mitigate CVE-2020-8554, enable the [`DenyServiceExternalIPs` admission controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#denyserviceexternalips) on the cluster.
 
 ## Installing the Chart
 


### PR DESCRIPTION
Kubernetes 1.21 introduced an in-tree admission controller to mitigate
the CVE that this webhook is created for. This change prevents
installation of the chart on 1.22, giving users one release of overlap
to migrate from the webhook to the admission controller.

https://github.com/rancher/rancher/issues/33893